### PR TITLE
performance improvement for SearchIntersect()

### DIFF
--- a/rtree.go
+++ b/rtree.go
@@ -427,17 +427,17 @@ func (tree *Rtree) condenseTree(n *node) {
 // Implemented per Section 3.1 of "R-trees: A Dynamic Index Structure for
 // Spatial Searching" by A. Guttman, Proceedings of ACM SIGMOD, p. 47-57, 1984.
 func (tree *Rtree) SearchIntersect(bb *Rect) []Spatial {
-	return tree.searchIntersect(tree.root, bb)
+	results := []Spatial{}
+	return tree.searchIntersect(tree.root, bb, results)
 }
 
-func (tree *Rtree) searchIntersect(n *node, bb *Rect) []Spatial {
-	results := []Spatial{}
+func (tree *Rtree) searchIntersect(n *node, bb *Rect, results []Spatial) []Spatial {
 	for _, e := range n.entries {
 		if intersect(e.bb, bb) {
 			if n.leaf {
 				results = append(results, e.obj)
 			} else {
-				results = append(results, tree.searchIntersect(e.child, bb)...)
+				results = tree.searchIntersect(e.child, bb, results)
 			}
 		}
 	}


### PR DESCRIPTION
SearchIntersect used to allocate new array and resize it at every level of recursion. This lead to a performance bottleneck for searches that return many results. This change allocates array only once and then appends to this single array. In my tests this resulted in ~2x performance improvement on searches with many hits (100000 random points in 10000x10000 square, do 1000 lookups).

All tests pass.
